### PR TITLE
Add per-category radar icon scaling with 4.0x cap

### DIFF
--- a/Radar/scripts/mods/Radar/Radar.lua
+++ b/Radar/scripts/mods/Radar/Radar.lua
@@ -124,6 +124,84 @@ local ARTWORK_MODE_KIND_TO_SETTING = {
     pocketable_void_shield = "show_pocketable_void_shield",
 }
 
+local MARKER_SCALE_GROUP_BY_KIND = {
+    crate_unknown = "common_pickups_group",
+    pickup_ammo = "common_pickups_group",
+    pickup_ammo_small = "common_pickups_group",
+    pickup_ammo_big = "common_pickups_group",
+    pickup_grenade = "common_pickups_group",
+    pickup_medkit = "common_pickups_group",
+    pickup_stimm = "common_pickups_group",
+    pocketable_ammo_crate = "common_pickups_group",
+    pocketable_medical_crate = "common_pickups_group",
+    pocketable_syringe_ability = "common_pickups_group",
+    pocketable_syringe_corruption = "common_pickups_group",
+    pocketable_syringe_power = "common_pickups_group",
+    pocketable_syringe_speed = "common_pickups_group",
+    material_diamantine = "materials_group",
+    material_plasteel = "materials_group",
+    luggable_power_cell_teal = "primary_objective_group",
+    luggable_cryonic_rod = "primary_objective_group",
+    luggable_moebian_pox_zetaphyte_13_sample = "primary_objective_group",
+    luggable_vacuum_capsule = "primary_objective_group",
+    luggable_special_issue_ammo = "primary_objective_group",
+    luggable_prismata_crystal_repository = "primary_objective_group",
+    pickup_mortis_relic = "primary_objective_group",
+    pickup_coordinates_paper = "primary_objective_group",
+    pocketable_grimoire = "secondary_objective_group",
+    pocketable_scripture = "secondary_objective_group",
+    expedition_loot_converter = "expeditions_location_group",
+    expedition_objective_opportunity = "expeditions_location_group",
+    expedition_objective_transition = "expeditions_location_group",
+    expedition_objective_main_objective = "expeditions_location_group",
+    expedition_objective_extraction = "expeditions_location_group",
+    expedition_objective_arrival = "expeditions_location_group",
+    material_expeditions_currency = "expeditions_specific_group",
+    material_expeditions_loot = "expeditions_specific_group",
+    material_expeditions_loot_player_drop = "expeditions_specific_group",
+    luggable_data_reliquary = "expeditions_specific_group",
+    pickup_large_ammunition_crate = "expeditions_specific_group",
+    luggable_promethium_barrel = "expeditions_specific_group",
+    pocketable_anti_rad_stimm = "expeditions_specific_group",
+    pocketable_airstrike = "expeditions_specific_group",
+    pocketable_artillery_strike = "expeditions_specific_group",
+    pocketable_big_grenade = "expeditions_specific_group",
+    pocketable_landmine_explosive = "expeditions_specific_group",
+    pocketable_landmine_fire = "expeditions_specific_group",
+    pocketable_landmine_shock = "expeditions_specific_group",
+    pocketable_valkyrie_hover = "expeditions_specific_group",
+    pocketable_void_shield = "expeditions_specific_group",
+    pickup_martyr_skull = "martyr_s_skull_group",
+    luggable_power_cell_orange = "martyr_s_skull_group",
+    medicae_station = "environment_group",
+    luggable_socket = "environment_group",
+    pickup_heretic_idol = "environment_group",
+    pickup_ammo_cache_deployable = "deployables_group",
+    medical_crate_deployable = "deployables_group",
+    player_teammate = "players_group",
+    pickup_tainted_skull = "event_group",
+    pocketable_corrupted_auspex_scanner = "event_group",
+    pickup_saints = "event_group",
+    pickup_stolen_rations = "event_group",
+    pickup_unknown = "debug_group",
+}
+
+local ICON_SCALE_SETTING_BY_GROUP = {
+    common_pickups_group = "common_pickups_icon_scale",
+    materials_group = "materials_icon_scale",
+    primary_objective_group = "primary_objective_icon_scale",
+    secondary_objective_group = "secondary_objective_icon_scale",
+    expeditions_location_group = "expeditions_location_icon_scale",
+    expeditions_specific_group = "expeditions_specific_icon_scale",
+    martyr_s_skull_group = "martyr_s_skull_icon_scale",
+    environment_group = "environment_icon_scale",
+    deployables_group = "deployables_icon_scale",
+    enemies_group = "enemies_icon_scale",
+    players_group = "players_icon_scale",
+    event_group = "event_icon_scale",
+    debug_group = "debug_icon_scale",
+}
+
 local ARTWORK_MODE_SETTING_IDS = {
     "show_crates",
     "show_diamantine",
@@ -151,6 +229,36 @@ local function _normalize_marker_display_mode(value)
     end
 
     return "artwork"
+end
+
+function mod:get_marker_scale_group(kind)
+    if not kind then
+        return nil
+    end
+
+    if string.sub(tostring(kind), 1, 6) == "enemy_" then
+        return "enemies_group"
+    end
+
+    return MARKER_SCALE_GROUP_BY_KIND[kind]
+end
+
+function mod:get_marker_scale_factor(group_name)
+    local setting_id = ICON_SCALE_SETTING_BY_GROUP[group_name]
+
+    if not setting_id then
+        return 1
+    end
+
+    local value = tonumber(self:get(setting_id)) or 100
+
+    if value < 50 then
+        value = 50
+    elseif value > 300 then
+        value = 300
+    end
+
+    return value / 100
 end
 
 function mod:get_marker_display_mode(kind)

--- a/Radar/scripts/mods/Radar/Radar_data.lua
+++ b/Radar/scripts/mods/Radar/Radar_data.lua
@@ -34,6 +34,18 @@ local function _artwork_icon_off_dropdown(setting_id)
     }
 end
 
+local function _icon_scale_slider(setting_id)
+    return {
+        setting_id = setting_id,
+        title = "icon_size_percent",
+        type = "numeric",
+        default_value = 100,
+        range = { 50, 300 },
+        decimals_number = 0,
+        step_size_value = 5,
+    }
+end
+
 return {
     name = mod:localize("mod_name"),
     description = mod:localize("mod_description"),
@@ -61,12 +73,13 @@ return {
                         setting_id = "radar_size",
                         type = "numeric",
                         default_value = 180,
-                        range = { 100, 350 },
+                        range = { 100, 1200 },
                         decimals_number = 0,
                         step_size_value = 5,
                         change = function(new_value)
                             mod:set("radar_size", new_value)
-                            mod:set_radar_position(mod:get_radar_offset_x(new_value), mod:get_radar_offset_y(new_value), true)
+                            mod:set_radar_position(mod:get_radar_offset_x(new_value), mod:get_radar_offset_y(new_value),
+                                true)
                         end,
                         get = function()
                             return mod:get_radar_size()
@@ -302,6 +315,7 @@ return {
                 setting_id = "common_pickups_group",
                 type = "group",
                 sub_widgets = {
+                    _icon_scale_slider("common_pickups_icon_scale"),
                     _artwork_icon_off_dropdown("show_crates"),
                     {
                         setting_id = "show_ammo_small",
@@ -354,6 +368,7 @@ return {
                 setting_id = "materials_group",
                 type = "group",
                 sub_widgets = {
+                    _icon_scale_slider("materials_icon_scale"),
                     _artwork_icon_off_dropdown("show_diamantine"),
                     _artwork_icon_off_dropdown("show_plasteel"),
                 },
@@ -362,6 +377,7 @@ return {
                 setting_id = "primary_objective_group",
                 type = "group",
                 sub_widgets = {
+                    _icon_scale_slider("primary_objective_icon_scale"),
                     {
                         setting_id = "show_power_cell_teal",
                         type = "checkbox",
@@ -408,6 +424,7 @@ return {
                 setting_id = "secondary_objective_group",
                 type = "group",
                 sub_widgets = {
+                    _icon_scale_slider("secondary_objective_icon_scale"),
                     {
                         setting_id = "show_pocketable_grimoire",
                         type = "checkbox",
@@ -424,6 +441,7 @@ return {
                 setting_id = "expeditions_location_group",
                 type = "group",
                 sub_widgets = {
+                    _icon_scale_slider("expeditions_location_icon_scale"),
                     {
                         setting_id = "ignore_radar_range_for_expedition_markers",
                         type = "checkbox",
@@ -465,6 +483,7 @@ return {
                 setting_id = "expeditions_specific_group",
                 type = "group",
                 sub_widgets = {
+                    _icon_scale_slider("expeditions_specific_icon_scale"),
                     _artwork_icon_off_dropdown("show_expeditions_currency"),
                     _artwork_icon_off_dropdown("show_expeditions_loot"),
                     _artwork_icon_off_dropdown("show_expeditions_dropped_loot"),
@@ -502,6 +521,7 @@ return {
                 setting_id = "martyr_s_skull_group",
                 type = "group",
                 sub_widgets = {
+                    _icon_scale_slider("martyr_s_skull_icon_scale"),
                     {
                         setting_id = "show_martyr_skull",
                         type = "checkbox",
@@ -518,6 +538,7 @@ return {
                 setting_id = "environment_group",
                 type = "group",
                 sub_widgets = {
+                    _icon_scale_slider("environment_icon_scale"),
                     {
                         setting_id = "show_medicae_station",
                         type = "checkbox",
@@ -539,6 +560,7 @@ return {
                 setting_id = "deployables_group",
                 type = "group",
                 sub_widgets = {
+                    _icon_scale_slider("deployables_icon_scale"),
                     {
                         setting_id = "show_ammo_crate_deployable",
                         type = "checkbox",
@@ -555,6 +577,7 @@ return {
                 setting_id = "enemies_group",
                 type = "group",
                 sub_widgets = {
+                    _icon_scale_slider("enemies_icon_scale"),
                     {
                         setting_id = "enemy_display_style",
                         type = "dropdown",
@@ -612,6 +635,7 @@ return {
                 setting_id = "players_group",
                 type = "group",
                 sub_widgets = {
+                    _icon_scale_slider("players_icon_scale"),
                     {
                         setting_id = "show_teammates",
                         type = "checkbox",
@@ -646,6 +670,7 @@ return {
                 setting_id = "event_group",
                 type = "group",
                 sub_widgets = {
+                    _icon_scale_slider("event_icon_scale"),
                     {
                         setting_id = "show_tainted_skull",
                         type = "checkbox",
@@ -672,6 +697,7 @@ return {
                 setting_id = "debug_group",
                 type = "group",
                 sub_widgets = {
+                    _icon_scale_slider("debug_icon_scale"),
                     {
                         setting_id = "debug_mode",
                         type = "checkbox",

--- a/Radar/scripts/mods/Radar/Radar_localization.lua
+++ b/Radar/scripts/mods/Radar/Radar_localization.lua
@@ -1689,7 +1689,20 @@ return {
         ["zh-cn"] = "失窃口粮",
         ["zh-tw"] = "失竊口糧",
     },
-
+    icon_size_percent = {
+        en = "Icon size (%%)",
+        fr = "Taille des icônes (%%)",
+        de = "Symbolgröße (%%)",
+        it = "Dimensione icone (%%)",
+        es = "Tamaño de iconos (%%)",
+        pl = "Rozmiar ikon (%%)",
+        ["pt-br"] = "Tamanho dos ícones (%%)",
+        ["ru"] = "Размер значков (%%)",
+        ja = "アイコンサイズ (%%)",
+        ko = "아이콘 크기 (%%)",
+        ["zh-cn"] = "图标大小 (%%)",
+        ["zh-tw"] = "圖示大小 (%%)",
+    },
     debug_group = {
         en = "Debugging",
         fr = "Débogage",

--- a/Radar/scripts/mods/Radar/ui/hud_element_radar.lua
+++ b/Radar/scripts/mods/Radar/ui/hud_element_radar.lua
@@ -217,12 +217,12 @@ local PRESENTATIONS = {
     pickup_ammo_cache_deployable = {
         icon = "content/ui/materials/hud/interactions/icons/pocketable_ammo",
         color = _widget_color(255, 240, 210, 80),
-        size = 14,
+        size = 7,
     },
     pickup_medkit = {
         icon = "content/ui/materials/hud/interactions/icons/pocketable_medkit",
         color = _widget_color(255, 38, 205, 26),
-        size = 14,
+        size = 7,
     },
     medical_crate_deployable = {
         icon = "content/ui/materials/hud/interactions/icons/pocketable_medkit",
@@ -941,15 +941,35 @@ local function _icon_scale_factor()
 
     if scale < 0.6 then
         scale = 0.6
-    elseif scale > 2.0 then
-        scale = 2.0
+    elseif scale > 4.0 then
+        scale = 4.0
     end
 
     return scale
 end
 
-local function _scaled_icon_size(base_size)
-    local scaled = math.floor((tonumber(base_size) or 14) * _icon_scale_factor() + 0.5)
+local function _marker_group_scale_factor(target)
+    if not target or not mod.get_marker_scale_group or not mod.get_marker_scale_factor then
+        return 1
+    end
+
+    local group_name = mod:get_marker_scale_group(target.kind)
+
+    if not group_name then
+        return 1
+    end
+
+    return mod:get_marker_scale_factor(group_name)
+end
+
+local function _scaled_icon_size(base_size, target)
+    local final_scale = _icon_scale_factor() * _marker_group_scale_factor(target)
+
+    if final_scale > 4.0 then
+        final_scale = 4.0
+    end
+
+    local scaled = math.floor((tonumber(base_size) or 14) * final_scale + 0.5)
 
     if scaled < 10 then
         scaled = 10
@@ -1016,7 +1036,7 @@ local function _apply_marker_widget(widget, visual, x, y, z, target)
     local icon_style = widget.style.icon
     local title_icon_style = widget.style.title_icon
     local arrow_icon_style = widget.style.arrow_icon
-    local size = _scaled_icon_size(visual and visual.size or 14)
+    local size = _scaled_icon_size(visual and visual.size or 14, target)
     local color = _any_to_widget_color(visual and visual.color or nil)
     local vertical_state = target and target.vertical_state or nil
     local arrow_icon = nil
@@ -1367,7 +1387,7 @@ HudElementRadar.draw = function(self, dt, t, ui_renderer, render_settings, input
 
                 if px and py then
                     local visual = _target_visual(target)
-                    local icon_size = _scaled_icon_size(visual and visual.size or 14)
+                    local icon_size = _scaled_icon_size(visual and visual.size or 14, target)
                     local draw_x = center_x + px - icon_size / 2
                     local draw_y = center_y + py - icon_size / 2
                     local widget = self._marker_widgets[next_widget_index]


### PR DESCRIPTION
- add icon size sliders for all radar marker groups
- keep existing marker sizes as the default at 100%
- apply group scaling on top of optional radar-size-based icon scaling
- raise radar-size scaling cap to support larger radar sizes up to 1200
- cap the final combined icon scale at 4.0x to avoid oversized markers
- keep marker placement and detection behavior unchanged
- exclude the center self marker from group scaling
- reuse shared localization for repeated "Icon size (%)" slider labels