### PR TITLE
Remember Radar scroll position in DMF options view

### DIFF
--- a/Radar/scripts/mods/Radar/Radar.lua
+++ b/Radar/scripts/mods/Radar/Radar.lua
@@ -25,4 +25,64 @@ _install("Radar/scripts/mods/Radar/Radar_runtime_helpers", shared_env)
 _install("Radar/scripts/mods/Radar/Radar_expeditions", shared_env)
 _install("Radar/scripts/mods/Radar/Radar_tracking", shared_env)
 
+-- save scroll position
+-- Author: Alfthebigheaded
+local last_scroll_amount = 0
+local last_category = nil
+
+local function is_radar_category(self)
+    local selected_category = self._selected_category
+    if not selected_category then
+        return false
+    end
+
+    return selected_category == mod:localize("mod_name")
+end
+
+mod:hook_safe(CLASS.BaseView, "on_exit", function(self)
+    if self.view_name == "dmf_options_view" then
+        last_category = nil
+    end
+end)
+
+mod:hook_safe(CLASS.BaseView, "update", function(self)
+    if self.view_name ~= "dmf_options_view" then
+        return
+    end
+
+    local navigation_grids = self._navigation_grids
+    if not navigation_grids then
+        return
+    end
+
+    local settings_grid = navigation_grids[2]
+    if not settings_grid then
+        return
+    end
+
+    local scrollbar_widget = settings_grid._scrollbar_widget
+    if not scrollbar_widget or not scrollbar_widget.content then
+        return
+    end
+
+    local current_category = self._selected_category
+    local in_radar_category = is_radar_category(self)
+
+    --  Detect category switch into my mod
+    if in_radar_category and (last_category ~= current_category or last_category == nil) then
+        scrollbar_widget.content.scroll_value = last_scroll_amount
+        scrollbar_widget.content.value = last_scroll_amount
+    end
+
+    --  Always track scroll while inside my mod
+    if in_radar_category then
+        local scroll_progress = settings_grid._scroll_progress
+        if scroll_progress ~= nil and last_scroll_amount ~= scroll_progress then
+            last_scroll_amount = scroll_progress
+        end
+    end
+
+    last_category = current_category
+end)
+
 return mod


### PR DESCRIPTION
Restore the previous scrollbar position when returning to the Radar category in DMF options. This improves navigation for large settings pages without changing option behavior.