### PR TITLE
Fix expedition player-drop remnant tracking

### DIFF
--- a/Radar/scripts/mods/Radar/Radar_enemy_definitions.lua
+++ b/Radar/scripts/mods/Radar/Radar_enemy_definitions.lua
@@ -327,6 +327,8 @@ return function(env)
     }
     local PLAYER_SMART_TAG_SELECTION_PRIORITY = 300
     local PLAYER_SMART_TAG_RENDER_LAYER = 3
+    local EXPEDITION_PLAYER_DROP_SELECTION_PRIORITY = 650
+    local EXPEDITION_PLAYER_DROP_RENDER_LAYER = 6
 
     local function _enemy_radar_default_icon_size(category)
         if category == "horde" then
@@ -1118,6 +1120,10 @@ return function(env)
     end
 
     function mod:get_target_selection_priority(kind)
+        if kind == "material_expeditions_loot_player_drop" then
+            return EXPEDITION_PLAYER_DROP_SELECTION_PRIORITY
+        end
+
         if kind == "location_attention" or kind == "location_ping" or kind == "location_threat" then
             return PLAYER_SMART_TAG_SELECTION_PRIORITY
         end
@@ -1139,6 +1145,10 @@ return function(env)
     end
 
     function mod:get_target_render_layer(kind)
+        if kind == "material_expeditions_loot_player_drop" then
+            return EXPEDITION_PLAYER_DROP_RENDER_LAYER
+        end
+
         if kind == "location_attention" or kind == "location_ping" or kind == "location_threat" then
             return PLAYER_SMART_TAG_RENDER_LAYER
         end

--- a/Radar/scripts/mods/Radar/Radar_expeditions.lua
+++ b/Radar/scripts/mods/Radar/Radar_expeditions.lua
@@ -775,12 +775,8 @@ return function(env)
             return true
         end
 
-        if kind == "material_expeditions_loot_player_drop" then
-            if not _has_active_expedition_player_drop(unit) then
-                return false
-            end
-        end
-
+        -- Player-drop loot bookkeeping lives on the server; clients still identify the pickup by
+        -- pickup_type, so section filtering must not require the server-only dropped-loot table.
         local game_mode = _safe_game_mode()
         local active_section_index = _safe_expedition_active_section_index(game_mode)
 

--- a/Radar/scripts/mods/Radar/Radar_tracking.lua
+++ b/Radar/scripts/mods/Radar/Radar_tracking.lua
@@ -1486,6 +1486,7 @@ return function(env)
             if is_priority_target == nil then
                 is_priority_target = kind == "enemy_daemonhost" or _is_boss_marker_kind(kind) or
                     ENEMY_RADAR_DEFINITION_BY_KIND[kind] ~= nil or
+                    kind == "material_expeditions_loot_player_drop" or
                     kind == "location_attention" or
                     kind == "location_ping" or
                     kind == "location_threat"


### PR DESCRIPTION
Remove the client-side dependency on expedition loot handler dropped-loot bookkeeping for player-drop pickups, since that state is server-owned in live missions. Keep player-drop remnants prioritized so they survive radar marker caps once tracked.