### PR TITLE
Add expedition POI display modes with distance text

### DIFF
--- a/Radar/scripts/mods/Radar/Radar_data.lua
+++ b/Radar/scripts/mods/Radar/Radar_data.lua
@@ -100,6 +100,44 @@ local function _icon_marked_off_dropdown(setting_id, default_value)
     }
 end
 
+local function _expedition_marker_display_mode_dropdown(setting_id, default_value)
+    return {
+        setting_id = setting_id,
+        type = "dropdown",
+        default_value = default_value,
+        options = {
+            {
+                text = "display_style_icon_only",
+                value = "icon_only",
+            },
+            {
+                text = "display_style_icon_distance",
+                value = "icon_distance",
+            },
+            {
+                text = "radar_outline_off",
+                value = "off",
+            },
+        },
+        get = function()
+            local value = mod:get(setting_id)
+
+            if value == nil then
+                return default_value
+            end
+
+            if value == "icon_only" or value == "icon_distance" or value == "off" then
+                return value
+            end
+
+            return value == false and "off" or "icon_only"
+        end,
+        change = function(new_value)
+            mod:set(setting_id, new_value)
+        end,
+    }
+end
+
 local function _expedition_loot_marker_mode_dropdown(setting_id)
     return {
         setting_id = setting_id,
@@ -723,36 +761,24 @@ return {
                             type = "checkbox",
                             default_value = true,
                         },
-                        {
-                            setting_id = "show_expedition_objective_opportunity",
-                            type = "checkbox",
-                            default_value = true,
-                        },
-                        {
-                            setting_id = "show_expedition_objective_transition",
-                            type = "checkbox",
-                            default_value = true,
-                        },
-                        {
-                            setting_id = "show_expedition_objective_main_objective",
-                            type = "checkbox",
-                            default_value = true,
-                        },
-                        {
-                            setting_id = "show_expedition_objective_extraction",
-                            type = "checkbox",
-                            default_value = true,
-                        },
-                        {
-                            setting_id = "show_expedition_objective_arrival",
-                            type = "checkbox",
-                            default_value = true,
-                        },
-                        {
-                            setting_id = "show_expedition_loot_converter",
-                            type = "checkbox",
-                            default_value = true,
-                        },
+                        _expedition_marker_display_mode_dropdown(
+                            "show_expedition_objective_opportunity",
+                            "icon_distance"),
+                        _expedition_marker_display_mode_dropdown(
+                            "show_expedition_objective_transition",
+                            "icon_only"),
+                        _expedition_marker_display_mode_dropdown(
+                            "show_expedition_objective_main_objective",
+                            "icon_only"),
+                        _expedition_marker_display_mode_dropdown(
+                            "show_expedition_objective_extraction",
+                            "icon_only"),
+                        _expedition_marker_display_mode_dropdown(
+                            "show_expedition_objective_arrival",
+                            "icon_only"),
+                        _expedition_marker_display_mode_dropdown(
+                            "show_expedition_loot_converter",
+                            "icon_only"),
                     },
                 },
                 {

--- a/Radar/scripts/mods/Radar/Radar_enemy_definitions.lua
+++ b/Radar/scripts/mods/Radar/Radar_enemy_definitions.lua
@@ -170,6 +170,24 @@ return function(env)
         expedition_objective_arrival = true,
     }
 
+    EXPEDITION_MARKER_DISPLAY_MODE_KIND_TO_SETTING = {
+        expedition_loot_converter = "show_expedition_loot_converter",
+        expedition_objective_opportunity = "show_expedition_objective_opportunity",
+        expedition_objective_transition = "show_expedition_objective_transition",
+        expedition_objective_main_objective = "show_expedition_objective_main_objective",
+        expedition_objective_extraction = "show_expedition_objective_extraction",
+        expedition_objective_arrival = "show_expedition_objective_arrival",
+    }
+
+    EXPEDITION_MARKER_DISPLAY_MODE_DEFAULT_BY_SETTING = {
+        show_expedition_objective_opportunity = "icon_distance",
+        show_expedition_objective_transition = "icon_only",
+        show_expedition_objective_main_objective = "icon_only",
+        show_expedition_objective_extraction = "icon_only",
+        show_expedition_objective_arrival = "icon_only",
+        show_expedition_loot_converter = "icon_only",
+    }
+
     EXPEDITION_OBJECTIVE_ICON_DEFAULTS = {
         expedition_loot_converter = "content/ui/materials/hud/interactions/icons/expeditions",
         expedition_objective_transition = "content/ui/materials/backgrounds/scanner/scanner_map_exit",
@@ -912,6 +930,15 @@ return function(env)
         "show_pocketable_void_shield",
     }
 
+    EXPEDITION_MARKER_DISPLAY_MODE_SETTING_IDS = {
+        "show_expedition_objective_opportunity",
+        "show_expedition_objective_transition",
+        "show_expedition_objective_main_objective",
+        "show_expedition_objective_extraction",
+        "show_expedition_objective_arrival",
+        "show_expedition_loot_converter",
+    }
+
     EXPEDITION_LOOT_VALUE_BY_PICKUP_NAME = {
         expedition_loot_small_tier_1 = 10,
         expedition_loot_small_tier_2 = 25,
@@ -1015,6 +1042,22 @@ return function(env)
         end
 
         return "artwork"
+    end
+
+    local function _normalize_expedition_marker_display_mode(value, default_value)
+        if value == "icon_only" or value == "icon_distance" or value == "off" then
+            return value
+        end
+
+        if value == false then
+            return "off"
+        end
+
+        if value == true then
+            return "icon_only"
+        end
+
+        return default_value or "icon_only"
     end
 
     function mod:get_marker_scale_group(kind)
@@ -1178,6 +1221,18 @@ return function(env)
         return _normalize_marker_display_mode(mod:get(setting_id))
     end
 
+    function mod:get_expedition_marker_display_mode(kind)
+        local setting_id = EXPEDITION_MARKER_DISPLAY_MODE_KIND_TO_SETTING[kind]
+        if not setting_id then
+            return nil
+        end
+
+        return _normalize_expedition_marker_display_mode(
+            mod:get(setting_id),
+            EXPEDITION_MARKER_DISPLAY_MODE_DEFAULT_BY_SETTING[setting_id]
+        )
+    end
+
     local function _migrate_marker_display_mode_settings()
         local mod_get = mod.get
         local mod_set = mod.set
@@ -1188,6 +1243,22 @@ return function(env)
 
             if value == true then
                 mod_set(mod, setting_id, "artwork")
+            elseif value == false then
+                mod_set(mod, setting_id, "off")
+            end
+        end
+    end
+
+    local function _migrate_expedition_marker_display_mode_settings()
+        local mod_get = mod.get
+        local mod_set = mod.set
+
+        for i = 1, #EXPEDITION_MARKER_DISPLAY_MODE_SETTING_IDS do
+            local setting_id = EXPEDITION_MARKER_DISPLAY_MODE_SETTING_IDS[i]
+            local value = mod_get(mod, setting_id)
+
+            if value == true then
+                mod_set(mod, setting_id, "icon_only")
             elseif value == false then
                 mod_set(mod, setting_id, "off")
             end
@@ -1207,6 +1278,7 @@ return function(env)
 
     function mod.on_all_mods_loaded()
         _migrate_marker_display_mode_settings()
+        _migrate_expedition_marker_display_mode_settings()
         _migrate_player_visibility_settings()
 
         local debug_mode = mod:get("debug_mode") == true

--- a/Radar/scripts/mods/Radar/Radar_expeditions.lua
+++ b/Radar/scripts/mods/Radar/Radar_expeditions.lua
@@ -721,6 +721,7 @@ return function(env)
 
     function _kind_enabled(kind)
         local get_enemy_marker_mode = mod.get_enemy_marker_mode
+        local get_expedition_marker_display_mode = mod.get_expedition_marker_display_mode
         local get_marker_display_mode = mod.get_marker_display_mode
         local get_setting = mod.get
         local enemy_display_mode = get_enemy_marker_mode(mod, kind)
@@ -735,6 +736,12 @@ return function(env)
 
         if enemy_display_mode ~= nil then
             return enemy_display_mode ~= "off"
+        end
+
+        local expedition_display_mode = get_expedition_marker_display_mode and
+            get_expedition_marker_display_mode(mod, kind) or nil
+        if expedition_display_mode ~= nil then
+            return expedition_display_mode ~= "off"
         end
 
         local display_mode = get_marker_display_mode(mod, kind)

--- a/Radar/scripts/mods/Radar/Radar_localization.lua
+++ b/Radar/scripts/mods/Radar/Radar_localization.lua
@@ -1072,6 +1072,7 @@ return {
         ["zh-cn"] = "仅图标",
         ["zh-tw"] = "僅圖示",
     },
+    display_style_icon_distance = _localized_text_for_all_languages("Icon + Distance m"),
     display_style_marked_icon = {
         en = "Marked icon",
         fr = "Icône marquée",

--- a/Radar/scripts/mods/Radar/ui/Radar_hud_element.lua
+++ b/Radar/scripts/mods/Radar/ui/Radar_hud_element.lua
@@ -597,6 +597,7 @@ end
 local _icon_scale_factor
 local _draw_cache = {
     marker_display_mode_by_kind = {},
+    expedition_marker_display_mode_by_kind = {},
     enemy_marker_mode_by_kind = {},
     marker_scale_by_group = {},
     enemy_scale_by_kind = {},
@@ -623,6 +624,7 @@ local function _build_draw_cache()
     local get_nearby_highlight_thickness = mod.get_nearby_highlight_thickness
 
     table_clear(draw_cache.marker_display_mode_by_kind)
+    table_clear(draw_cache.expedition_marker_display_mode_by_kind)
     table_clear(draw_cache.enemy_marker_mode_by_kind)
     table_clear(draw_cache.marker_scale_by_group)
     table_clear(draw_cache.enemy_scale_by_kind)
@@ -1545,6 +1547,45 @@ local function _player_smart_tag_distance_text(target, draw_cache)
     return _distance_text_from_squared_distance(target and target.distance_sq_3d, " m")
 end
 
+local function _cached_expedition_marker_display_mode(kind, draw_cache)
+    if kind == nil then
+        return nil
+    end
+
+    local cache = draw_cache and draw_cache.expedition_marker_display_mode_by_kind or nil
+
+    if cache then
+        local cached = cache[kind]
+
+        if cached ~= nil then
+            return cached
+        end
+    end
+
+    local get_expedition_marker_display_mode = mod.get_expedition_marker_display_mode
+    local mode = get_expedition_marker_display_mode and get_expedition_marker_display_mode(mod, kind) or nil
+
+    if cache then
+        cache[kind] = mode or false
+    end
+
+    return mode
+end
+
+local function _expedition_marker_distance_text(target, draw_cache)
+    local kind = target and target.kind or nil
+
+    if not _is_expedition_objective_kind(kind) then
+        return nil
+    end
+
+    if _cached_expedition_marker_display_mode(kind, draw_cache) ~= "icon_distance" then
+        return nil
+    end
+
+    return _distance_text_from_squared_distance(target and target.distance_sq_3d, " m")
+end
+
 local function _apply_target_specific_visual_overrides(target, visual, draw_cache)
     if not visual then
         return nil
@@ -1604,6 +1645,19 @@ local function _apply_target_specific_visual_overrides(target, visual, draw_cach
     if boss_distance_text ~= nil then
         local result = _copy_visual(visual)
         result.value_text = boss_distance_text
+        result.value_text_color = BOSS_DISTANCE_TEXT_WIDGET_COLOR
+        result.value_text_anchor = "bottom_center"
+        result.value_text_offset_x = 3
+        result.value_text_offset_y = -3
+
+        return result
+    end
+
+    local expedition_marker_distance_text = _expedition_marker_distance_text(target, draw_cache)
+
+    if expedition_marker_distance_text ~= nil then
+        local result = _copy_visual(visual)
+        result.value_text = expedition_marker_distance_text
         result.value_text_color = BOSS_DISTANCE_TEXT_WIDGET_COLOR
         result.value_text_anchor = "bottom_center"
         result.value_text_offset_x = 3
@@ -1873,7 +1927,8 @@ local function _target_visual(target, draw_cache)
             )
         end
 
-        return _expedition_objective_visual(target, draw_cache)
+        return _apply_target_specific_visual_overrides(target, _expedition_objective_visual(target, draw_cache),
+            draw_cache)
     end
 
     local icon_visual = _artwork_mode_icon_visual(target_kind, draw_cache)


### PR DESCRIPTION
Replace expedition POI boolean toggles with dropdown display modes: Icon only, Icon + Distance m, and Off. Migrate existing boolean settings so enabled POIs remain icon-only and disabled POIs stay hidden.

Render meter distance text for expedition POIs when the distance mode is selected, matching the existing boss distance presentation.