### PR TITLE
Fix missing expedition artwork package preload

### DIFF
--- a/Radar/scripts/mods/Radar/Radar_data.lua
+++ b/Radar/scripts/mods/Radar/Radar_data.lua
@@ -42,6 +42,7 @@ local REQUIRED_ICON_PACKAGES = {
     "packages/ui/material_sets/circumstances",
     "packages/ui/views/crafting_view/crafting_view",
     "packages/ui/views/penance_overview_view/penance_overview_view",
+    "packages/ui/views/expedition_play_view/expedition_play_view",
 }
 
 local ARTWORK_DROPDOWN_PRESENTATIONS = {

--- a/Radar/scripts/mods/Radar/Radar_enemy_definitions.lua
+++ b/Radar/scripts/mods/Radar/Radar_enemy_definitions.lua
@@ -1425,6 +1425,7 @@ return function(env)
         load_package("packages/ui/material_sets/circumstances")
         load_package("packages/ui/views/crafting_view/crafting_view")
         load_package("packages/ui/views/penance_overview_view/penance_overview_view")
+        load_package("packages/ui/views/expedition_play_view/expedition_play_view")
 
         if debug_mode then
             mod:info("Packages loaded")


### PR DESCRIPTION
Preload expedition_play_view so Tech-Remnant and expedition crate artwork materials are available during Radar rendering instead of showing as white fallback squares for some mod/load-order setups.