### PR TITLE
Keep Heretic Idol markers visible across vertical levels

### DIFF
--- a/Radar/scripts/mods/Radar/Radar_tracking.lua
+++ b/Radar/scripts/mods/Radar/Radar_tracking.lua
@@ -2031,7 +2031,9 @@ return function(env)
                 if vertical_delta ~= nil then
                     local abs_vertical_delta = math_abs(vertical_delta)
 
-                    if not infinite_range and abs_vertical_delta >= item_vertical_hide_threshold then
+                    if not infinite_range
+                        and kind ~= "pickup_heretic_idol"
+                        and abs_vertical_delta >= item_vertical_hide_threshold then
                         return
                     end
 


### PR DESCRIPTION
Prevent Heretic Idol radar markers from being hidden by the shared above/below vertical hide threshold while preserving normal range, settings, and arrow overlay behavior for all other marker types.