### PR TITLE
Improve Radar performance with per-frame work reduction

### DIFF
--- a/Radar/scripts/mods/Radar/Radar_expeditions.lua
+++ b/Radar/scripts/mods/Radar/Radar_expeditions.lua
@@ -600,8 +600,45 @@ return function(env)
         return _is_radar_enabled_for_current_mode(mission_name, mechanism_name)
     end
 
+    local _runtime_state_cached_t = nil
+    local _runtime_state_allowed = false
+    local _runtime_state_reason = nil
+    local _runtime_state_mission_name = nil
+    local _runtime_state_activity = nil
+    local _runtime_state_mechanism_name = nil
+    local _runtime_state_player_unit = nil
+    local _runtime_state_player_pos = nil
+
+    function _invalidate_runtime_state_cache()
+        _runtime_state_cached_t = nil
+    end
+
+    local function _store_runtime_state(allowed, reason, gameplay_t, mission_name, activity, mechanism_name,
+                                        player_unit, player_pos)
+        _runtime_state_cached_t = gameplay_t
+        _runtime_state_allowed = allowed
+        _runtime_state_reason = reason
+        _runtime_state_mission_name = mission_name
+        _runtime_state_activity = activity
+        _runtime_state_mechanism_name = mechanism_name
+        _runtime_state_player_unit = player_unit
+        _runtime_state_player_pos = player_pos
+
+        return allowed, reason, gameplay_t, mission_name, activity, mechanism_name, player_unit, player_pos
+    end
+
     function _get_runtime_state()
         local gameplay_t = _safe_gameplay_time()
+
+        -- The runtime state is queried several times per frame (scan hook, DMF
+        -- update and HUD draw); reuse the result computed for the current
+        -- gameplay tick instead of re-deriving it from the managers each time.
+        if gameplay_t ~= nil and gameplay_t == _runtime_state_cached_t then
+            return _runtime_state_allowed, _runtime_state_reason, gameplay_t, _runtime_state_mission_name,
+                _runtime_state_activity, _runtime_state_mechanism_name, _runtime_state_player_unit,
+                _runtime_state_player_pos
+        end
+
         local mission_name = _safe_mission_name()
         local activity = _safe_presence_activity()
         local mechanism_name = _safe_mechanism_name()
@@ -609,54 +646,62 @@ return function(env)
         local player_pos = _safe_unit_position(player_unit)
 
         if activity == "loading" then
-            return false, "loading", gameplay_t, mission_name, activity, mechanism_name, player_unit, player_pos
+            return _store_runtime_state(false, "loading", gameplay_t, mission_name, activity, mechanism_name,
+                player_unit, player_pos)
         end
 
         if mechanism_name == "left_session" or mechanism_name == "hub" then
-            return false, "hub_mechanism", gameplay_t, mission_name, activity, mechanism_name, player_unit, player_pos
+            return _store_runtime_state(false, "hub_mechanism", gameplay_t, mission_name, activity, mechanism_name,
+                player_unit, player_pos)
         end
 
         if not mission_name then
-            return false, "no_mission", gameplay_t, mission_name, activity, mechanism_name, player_unit, player_pos
+            return _store_runtime_state(false, "no_mission", gameplay_t, mission_name, activity, mechanism_name,
+                player_unit, player_pos)
         end
 
         if mission_name == "hub_ship" then
-            return false, "hub_mission", gameplay_t, mission_name, activity, mechanism_name, player_unit, player_pos
+            return _store_runtime_state(false, "hub_mission", gameplay_t, mission_name, activity, mechanism_name,
+                player_unit, player_pos)
         end
 
         if mechanism_name == "onboarding" and mission_name ~= "tg_shooting_range" then
-            return false, "onboarding_non_psykhanium", gameplay_t, mission_name, activity, mechanism_name, player_unit,
-                player_pos
+            return _store_runtime_state(false, "onboarding_non_psykhanium", gameplay_t, mission_name, activity,
+                mechanism_name, player_unit, player_pos)
         end
 
         if _is_hub_runtime(mission_name, activity, mechanism_name) then
-            return false, "hub_runtime", gameplay_t, mission_name, activity, mechanism_name, player_unit, player_pos
+            return _store_runtime_state(false, "hub_runtime", gameplay_t, mission_name, activity, mechanism_name,
+                player_unit, player_pos)
         end
 
         if not mod:is_radar_runtime_game_mode_allowed() then
-            return false, "game_mode_disabled", gameplay_t, mission_name, activity, mechanism_name, player_unit,
-                player_pos
+            return _store_runtime_state(false, "game_mode_disabled", gameplay_t, mission_name, activity, mechanism_name,
+                player_unit, player_pos)
         end
 
         if _is_local_player_using_foreign_unit(player_unit) then
-            return false, "spectating_teammate", gameplay_t, mission_name, activity, mechanism_name, player_unit,
-                player_pos
+            return _store_runtime_state(false, "spectating_teammate", gameplay_t, mission_name, activity, mechanism_name,
+                player_unit, player_pos)
         end
 
         if not _is_player_unit_alive(player_unit) then
-            return false, "player_not_alive", gameplay_t, mission_name, activity, mechanism_name, player_unit, player_pos
+            return _store_runtime_state(false, "player_not_alive", gameplay_t, mission_name, activity, mechanism_name,
+                player_unit, player_pos)
         end
 
         if _is_player_unit_captured(player_unit) then
-            return false, "player_captured", gameplay_t, mission_name, activity, mechanism_name, player_unit, player_pos
+            return _store_runtime_state(false, "player_captured", gameplay_t, mission_name, activity, mechanism_name,
+                player_unit, player_pos)
         end
 
         if not player_pos then
-            return false, "no_player_position", gameplay_t, mission_name, activity, mechanism_name, player_unit,
-                player_pos
+            return _store_runtime_state(false, "no_player_position", gameplay_t, mission_name, activity, mechanism_name,
+                player_unit, player_pos)
         end
 
-        return true, "ok", gameplay_t, mission_name, activity, mechanism_name, player_unit, player_pos
+        return _store_runtime_state(true, "ok", gameplay_t, mission_name, activity, mechanism_name, player_unit,
+            player_pos)
     end
 
     function _is_allowed_runtime()
@@ -1015,36 +1060,45 @@ return function(env)
         return kind, meta
     end
 
+    -- Breed classification is a pure function of static tables, so cache the
+    -- result per breed name (`false` marks breeds without a radar kind) to keep
+    -- the string scans out of the per-minion scan loop.
+    local _enemy_kind_by_breed_cache = {}
+
     function _classify_enemy_from_breed(breed_name)
-        local key = string_lower(breed_name or "")
+        local cache_key = breed_name or ""
+        local cached = _enemy_kind_by_breed_cache[cache_key]
+
+        if cached ~= nil then
+            return cached or nil
+        end
+
+        local key = string_lower(cache_key)
+        local kind = nil
 
         if key == "chaos_daemonhost" or key == "chaos_mutator_daemonhost" or string_find(key, "daemonhost", 1, true) then
-            return "enemy_daemonhost"
-        end
-
-        if TWIN_BREEDS[key] or string_find(key, "twin_captain", 1, true) then
-            return "enemy_karnak_twin"
-        end
-
-        if CAPTAIN_BREEDS[key] or string_find(key, "captain", 1, true) then
-            return "enemy_captain"
-        end
-
-        if MONSTROSITY_BREEDS[key]
+            kind = "enemy_daemonhost"
+        elseif TWIN_BREEDS[key] or string_find(key, "twin_captain", 1, true) then
+            kind = "enemy_karnak_twin"
+        elseif CAPTAIN_BREEDS[key] or string_find(key, "captain", 1, true) then
+            kind = "enemy_captain"
+        elseif MONSTROSITY_BREEDS[key]
             or string_find(key, "beast_of_nurgle", 1, true)
             or string_find(key, "plague_ogryn", 1, true)
             or string_find(key, "chaos_spawn", 1, true)
             or string_find(key, "houndmaster", 1, true) then
-            return "enemy_monstrosity"
+            kind = "enemy_monstrosity"
+        else
+            local definition = ENEMY_RADAR_DEFINITIONS_BY_BREED[key]
+
+            if definition then
+                kind = definition.kind
+            end
         end
 
-        local definition = ENEMY_RADAR_DEFINITIONS_BY_BREED[key]
+        _enemy_kind_by_breed_cache[cache_key] = kind or false
 
-        if definition then
-            return definition.kind
-        end
-
-        return nil
+        return kind
     end
 
     function _track_unit(unit, kind, source, meta)

--- a/Radar/scripts/mods/Radar/Radar_tracking.lua
+++ b/Radar/scripts/mods/Radar/Radar_tracking.lua
@@ -29,6 +29,7 @@ return function(env)
             t[k] = nil
         end
     end
+    local os_clock = os and os.clock or nil
 
 
     local function _reuse_or_new_table(t)
@@ -65,12 +66,18 @@ return function(env)
     local _scratch_seen_destructibles = {}
     local _scratch_seen_hazard_props = {}
     local _scratch_mastiff_disabled_enemy_units = {}
+    local _scratch_minion_kind_enabled_cache = {}
     local OVERVIEW_MIN_ZOOM_RANGE = 25
     local OVERVIEW_MAX_ZOOM_RANGE = 500
     local OVERVIEW_DEFAULT_ZOOM_RANGE = OVERVIEW_MAX_ZOOM_RANGE
     local OVERVIEW_SCREEN_PADDING = 80
     local OVERVIEW_RANGE_TRANSITION_DURATION = 0.28
     local OVERVIEW_RANGE_TRANSITION_SCAN_INTERVAL = 0.05
+    -- Static or slow-changing sources (interactables, chests, destructibles,
+    -- hazard props, deployed smart-tag targets) are rescanned less often than
+    -- enemies and players. Dead/despawned units are still removed at the fast
+    -- cadence by `_prune_units`.
+    local STATIC_SCAN_INTERVAL = SCAN_INTERVAL * 2
     local OVERVIEW_RESET_FIT_EDGE_FRACTION = 0.9
     local OVERVIEW_RADAR_MARKER_LIMIT = 300
     local NORMAL_RADAR_MIN_ZOOM_RANGE = 10
@@ -1355,6 +1362,8 @@ return function(env)
         local local_combat_ability_name = show_ability_marked_enemies
             and _safe_unit_ability_name(local_player_unit, "combat_ability")
             or nil
+        local kind_enabled_cache = _scratch_minion_kind_enabled_cache
+        table_clear(kind_enabled_cache)
 
         for unit, extension in pairs(unit_data_map) do
             if _safe_unit_alive(unit) and extension then
@@ -1367,6 +1376,15 @@ return function(env)
                         local resolved_breed_name = _resolve_enemy_breed_name(unit, breed_name)
                         local kind = _classify_enemy_from_breed(resolved_breed_name)
                         if kind and _is_trackable_unit_alive(unit, kind) then
+                            local kind_enabled = kind_enabled_cache[kind]
+
+                            if kind_enabled == nil then
+                                kind_enabled = _kind_enabled(kind)
+                                kind_enabled_cache[kind] = kind_enabled
+                            end
+
+                            -- Disabled enemy kinds skip tracking work entirely unless an
+                            -- ability mark can still surface the unit on the radar.
                             local ability_marker_names = nil
                             local ability_marker_bracket_color = nil
 
@@ -1380,12 +1398,16 @@ return function(env)
                                     )
                             end
 
-                            _track_unit(unit, kind, "unit_data_system", {
-                                breed_name = breed_name,
-                                marked_by_player_slot = track_enemy_tags and _marked_by_player_slot_for_unit(unit) or nil,
-                                ability_marked = ability_marker_names ~= nil,
-                                ability_outline_bracket_color = ability_marker_bracket_color,
-                            })
+                            if kind_enabled or ability_marker_names ~= nil then
+                                _track_unit(unit, kind, "unit_data_system", {
+                                    breed_name = breed_name,
+                                    marked_by_player_slot = track_enemy_tags and _marked_by_player_slot_for_unit(unit) or nil,
+                                    ability_marked = ability_marker_names ~= nil,
+                                    ability_outline_bracket_color = ability_marker_bracket_color,
+                                })
+                            else
+                                _clear_tracked_unit_from_source(unit, "unit_data_system")
+                            end
                         end
                     end
                 end
@@ -2210,7 +2232,7 @@ return function(env)
         mod._last_scan_signature = signature
 
         mod:info(string_format(
-            "Radar scan | enemies=%d players=%d ammo=%d crates=%d pocketables=%d materials=%d generic=%d tracked=%d radar_targets=%d mission=%s activity=%s mechanism=%s player_state=%s",
+            "Radar scan | enemies=%d players=%d ammo=%d crates=%d pocketables=%d materials=%d generic=%d tracked=%d radar_targets=%d scan_ms=%.2f mission=%s activity=%s mechanism=%s player_state=%s",
             counts.enemies,
             counts.players,
             counts.ammo,
@@ -2220,6 +2242,7 @@ return function(env)
             counts.generic,
             _table_size(mod._tracked_units),
             #mod._radar_targets,
+            tonumber(mod._last_scan_cost_ms) or -1,
             tostring(_safe_mission_name()),
             tostring(_safe_presence_activity()),
             tostring(_safe_mechanism_name()),
@@ -2232,6 +2255,9 @@ return function(env)
         mod._unclustered_radar_targets = {}
         mod._highlight_source_radar_targets = {}
         mod._next_scan_t = 0
+        mod._next_static_scan_t = 0
+        mod._last_scan_cost_ms = nil
+        _invalidate_runtime_state_cache()
         mod._tracked_units = {}
         mod._tracked_points = {}
         mod._logged_units = {}
@@ -2365,13 +2391,29 @@ return function(env)
 
         mod._next_scan_t = scan_clock + scan_interval
 
+        local static_scan_due = scan_clock >= (mod._next_static_scan_t or 0)
+
+        if static_scan_due then
+            mod._next_static_scan_t = scan_clock + STATIC_SCAN_INTERVAL
+        end
+
+        local scan_start_time = mod:get("debug_mode") == true and os_clock and os_clock() or nil
+
         _sync_expedition_item_state()
-        _scan_interactees()
-        _scan_chests()
+
+        if static_scan_due then
+            _scan_interactees()
+            _scan_chests()
+        end
+
         _scan_minions()
-        _scan_destructibles()
-        _scan_hazard_props()
-        _scan_smart_tag_targets()
+
+        if static_scan_due then
+            _scan_destructibles()
+            _scan_hazard_props()
+            _scan_smart_tag_targets()
+        end
+
         _refresh_player_units()
         _scan_expedition_objectives()
         _scan_player_tag_points()
@@ -2381,6 +2423,10 @@ return function(env)
         mod._screen_highlight_targets = _collect_screen_highlight_targets()
         mod._radar_snapshot = _collect_radar_snapshot()
 
+        if scan_start_time then
+            mod._last_scan_cost_ms = (os_clock() - scan_start_time) * 1000
+        end
+
         _debug_log_scan()
     end
 
@@ -2389,7 +2435,9 @@ return function(env)
             mod._gameplay_run = true
             _warm_radar_target_pool(512)
             mod._next_scan_t = 0
+            mod._next_static_scan_t = 0
             mod._last_update_t = nil
+            _invalidate_runtime_state_cache()
             return
         end
 
@@ -2679,16 +2727,8 @@ return function(env)
             return false
         end
 
-        if not _is_radar_keybind_runtime_allowed() then
-            return false
-        end
-
-        local should_capture = self:is_overview_mode_active() or self:is_normal_radar_zoom_modifier_active()
-
-        if not should_capture then
-            return false
-        end
-
+        -- This runs inside the InputService hooks for every action lookup, so
+        -- check the cheap captured-action table before touching runtime state.
         local capture_actions = self._overview_capture_actions
 
         if capture_actions == nil then
@@ -2696,7 +2736,15 @@ return function(env)
             capture_actions = self._overview_capture_actions
         end
 
-        return capture_actions[tostring(action_name)] == true
+        if capture_actions[tostring(action_name)] ~= true then
+            return false
+        end
+
+        if not (self:is_overview_mode_active() or self:is_normal_radar_zoom_modifier_active()) then
+            return false
+        end
+
+        return _is_radar_keybind_runtime_allowed()
     end
 
     function mod:get_player_display_style()

--- a/Radar/scripts/mods/Radar/ui/Radar_hud_element.lua
+++ b/Radar/scripts/mods/Radar/ui/Radar_hud_element.lua
@@ -763,7 +763,11 @@ local function _normalized_enemy_display_style(value)
 end
 
 local _icon_scale_factor
+local DRAW_CACHE_REFRESH_INTERVAL = 1
 local _draw_cache = {
+    valid = false,
+    color_generation = nil,
+    next_refresh_t = nil,
     marker_display_mode_by_kind = {},
     expedition_marker_display_mode_by_kind = {},
     icon_distance_marker_display_mode_by_kind = {},
@@ -793,8 +797,22 @@ local _draw_cache = {
     marker_distance_text_color = BOSS_DISTANCE_TEXT_WIDGET_COLOR,
 }
 
-local function _build_draw_cache()
+local function _build_draw_cache(t)
     local draw_cache = _draw_cache
+    local color_generation = mod._radar_color_cache_generation
+    local now = tonumber(t)
+
+    -- Every value below derives from mod settings (any change bumps the color
+    -- cache generation) or from globals/managers that the timed refresh keeps
+    -- from going stale, so skip the rebuild on frames where nothing changed.
+    if draw_cache.valid
+        and draw_cache.color_generation == color_generation
+        and now ~= nil
+        and draw_cache.next_refresh_t ~= nil
+        and now < draw_cache.next_refresh_t then
+        return draw_cache
+    end
+
     local get = mod.get
     local get_show_player_center_dot = mod.get_show_player_center_dot
     local get_player_display_style = mod.get_player_display_style
@@ -877,6 +895,10 @@ local function _build_draw_cache()
         draw_cache.game_object_field = game_session_api and game_session_api.game_object_field or nil
         draw_cache.game_object_exists = game_session_api and game_session_api.game_object_exists or nil
     end
+
+    draw_cache.valid = true
+    draw_cache.color_generation = color_generation
+    draw_cache.next_refresh_t = now and (now + DRAW_CACHE_REFRESH_INTERVAL) or nil
 
     return draw_cache
 end
@@ -2923,11 +2945,11 @@ local function _target_radius_icon_size(_target, visual, projection_radius, rada
     return math_max(1, math_floor(radius_pixels * 2 + 0.5))
 end
 
-local function _draw_internal(self, ui_renderer, snapshot)
+local function _draw_internal(self, ui_renderer, snapshot, t)
     RadarHudWidgets.ensure_overview_scale_widget(self)
     RadarHudWidgets.ensure_marker_widgets(self)
 
-    local draw_cache = _build_draw_cache()
+    local draw_cache = _build_draw_cache(t)
     local marker_widgets = self._marker_widgets
     local size = mod:get_radar_size()
     local range = mod:get_radar_range()
@@ -3248,7 +3270,7 @@ HudElementRadar.draw = function(self, dt, t, ui_renderer, render_settings, input
 
     UIRenderer_begin_pass(ui_renderer, self._ui_scenegraph, input_service, dt, render_settings)
 
-    local ok, err = pcall(_draw_internal, self, ui_renderer, snapshot)
+    local ok, err = pcall(_draw_internal, self, ui_renderer, snapshot, t)
 
     UIRenderer_end_pass(ui_renderer)
 


### PR DESCRIPTION
Radar rebuilt settings-derived state and re-ran runtime gating multiple times per frame, and rescanned all marker sources every scan tick. As more marker types were added this per-frame cost grew, especially in dense combat and marker-heavy missions.

Optimize the three hot paths while preserving all radar behavior and visual output:

- HUD draw: rebuild the settings-derived draw cache only when a mod setting changes (via the existing color-cache generation counter) or after a 1s safety refresh, instead of every frame.
- Runtime gating: memoize _get_runtime_state per gameplay tick so the scan hook, DMF update and HUD draw share one result; invalidate on game-state resets.
- Input hook: reorder should_capture_overview_input_action so the common case is a single table lookup before touching runtime state.
- Scan path: memoize breed classification per breed name, skip tracking work for disabled enemy kinds (honoring the ability-mark bypass), and rescan static sources (interactables, chests, destructibles, hazard props, deployed smart-tag targets) at half cadence. Dead units are still pruned every fast tick.
- Add scan_ms timing to the debug scan log for measurability.